### PR TITLE
Minify HTML 

### DIFF
--- a/lib/mjml-template-render.js
+++ b/lib/mjml-template-render.js
@@ -18,7 +18,17 @@ TemplateGenerator.prototype.render = function render(mail, cb) {
     // Render the mjml template content
     var renderedMjmlTemplate = Mustache.render(templateContent, mail.data.context)
     // Render the mjml template with variables into normal html
-    let result = mjml(renderedMjmlTemplate)
+    let result = mjml(renderedMjmlTemplate, {minify: true})
+
+    // If there are any compilation issues with MJML, we will throw the errors
+    if (Object.keys(result.errors).length > 0) {
+      // We want to clean up the formatted message since it's a duplication of the errors already in the list
+      Object.keys(result.errors).forEach((key) => {
+        delete result.errors[key].formattedMessage
+      })
+      throw result.errors
+    }
+
     mail.data.html = result.html
     cb()
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodemailer-mjml-mustache",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A plugin for nodemailer that uses mjml and mustache view engine to generate emails.",
   "main": "lib/index.js",
   "repository": "git@github.com:etiennemarais/nodemailer-mjml-mustache.git",
@@ -9,7 +9,10 @@
     "nodemailer",
     "html",
     "mjml",
-    "mustache"
+    "mustache",
+    "html-templates",
+    "email",
+    "templates"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
# Summary

Solves #1 to minify the HTML output from rendering.

## Changes

- Bumped version
- Added option to minify html output
- Added error handling if there were any compilation errors in the mjml. These were getting swallowed upstream.

